### PR TITLE
Two fixes in WiTcontroller related to displaying battery percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,6 @@ Recommend adding a physical power switch as this will continually drain the batt
 
 ## Change Log
 
-### V1
-
 ### V1.52
 - Made two changes in main code 1. Comment out random values when displaying battery percentage
 - and 2.Invert logic for the test to display the battery percentage 

--- a/README.md.bak
+++ b/README.md.bak
@@ -294,12 +294,16 @@ Recommend adding a physical power switch as this will continually drain the batt
 *Pinouts for Optional Battery Monitor*
 ![Assembly diagram - Optional Battery Monitor](WiTcontroller%20-%20Optional%20battery%20monitor.png)
 
----.
+---
 ---
 
 ## Change Log
 
 ### V1
+
+### V1.52
+- Made two changes in main code 1. Comment out random values when displaying battery percentage
+- and 2.Invert logic for the test to display the battery percentage 
 
 ### V1.51
 - changed option to have the battery to show icon as well as a percent

--- a/README.md.bak
+++ b/README.md.bak
@@ -294,16 +294,12 @@ Recommend adding a physical power switch as this will continually drain the batt
 *Pinouts for Optional Battery Monitor*
 ![Assembly diagram - Optional Battery Monitor](WiTcontroller%20-%20Optional%20battery%20monitor.png)
 
----
+---.
 ---
 
 ## Change Log
 
 ### V1
-
-### V1.52
-- Made two changes in main code 1. Comment out random values when displaying battery percentage
-- and 2.Invert logic for the test to display the battery percentage 
 
 ### V1.51
 - changed option to have the battery to show icon as well as a percent

--- a/WiTcontroller.ino
+++ b/WiTcontroller.ino
@@ -2864,7 +2864,7 @@ void writeOledSpeed() {
   }
 
   if (useBatteryTest) {
-    int lastBatteryTestValue = random(0,100);
+    //int lastBatteryTestValue = random(0,100);
     u8g2.setFont(FONT_HEARTBEAT);
     u8g2.setDrawColor(1);
     u8g2.drawStr(1, 30, String("Z").c_str());
@@ -2875,7 +2875,7 @@ void writeOledSpeed() {
     if (lastBatteryTestValue>90) u8g2.drawLine(6, 24, 6, 27);
     
     u8g2.setFont(FONT_FUNCTION_INDICATORS);
-    if (!useBatteryPercentAsWellAsIcon) {
+    if (useBatteryPercentAsWellAsIcon) {
       u8g2.drawStr(1,22, String(String(lastBatteryTestValue)+"%").c_str());
     }
     if(lastBatteryTestValue<4) {


### PR DESCRIPTION
Two fixes made.
1. Comment out the random instruction in (useBatteryTest) {} code block in WiTcontroller.ino 
2. Change the logic for the if statement if (!useBatteryPercentAsWellAsIcon) to remove the NOT in the same code block.

Also updated README to inc version number and add comment