### PR TITLE
V1.53 - Add support for bare EC11 encoder hardware build

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ Recommend adding a physical power switch as this will continually drain the batt
 
 ## Change Log
 
+### V1.53
+- Add support for hardware build that utilises a bare EC11 rotary encoder (with no physical resistor pullups) in place of the KY040 encoder module (which incorporates physical pullups)
+- This version will switch on GPIO internal pullups if EC11_PULLUPS_REQUIRED is set true in config_buttons.h
+
 ### V1.52
 - Made two changes in main code 1. Comment out random values when displaying battery percentage
 - and 2.Invert logic for the test to display the battery percentage 

--- a/README.md.bak
+++ b/README.md.bak
@@ -299,8 +299,6 @@ Recommend adding a physical power switch as this will continually drain the batt
 
 ## Change Log
 
-### V1
-
 ### V1.52
 - Made two changes in main code 1. Comment out random values when displaying battery percentage
 - and 2.Invert logic for the test to display the battery percentage 

--- a/WiTcontroller.ino
+++ b/WiTcontroller.ino
@@ -1303,6 +1303,13 @@ void setup() {
   //rotaryEncoder.disableAcceleration(); //acceleration is now enabled by default - disable if you don't need it
   rotaryEncoder.setAcceleration(100); //or set the value - larger number = more acceleration; 0 or 1 means disabled acceleration
 
+  //if EC11 is used in hardware build WITHOUT physical pullup resistore, then make then enable GPIO pullups on EC11 A and B inputs
+  if (EC11_PULLUPS_REQUIRED) {
+    // debug_println("EC11 A and B input pins, enabling GPIO pullups " );
+    pinMode(ROTARY_ENCODER_A_PIN, INPUT_PULLUP);
+    pinMode(ROTARY_ENCODER_B_PIN, INPUT_PULLUP);
+  }
+
   keypad.addEventListener(keypadEvent); // Add an event listener for this keypad
   keypad.setDebounceTime(KEYPAD_DEBOUNCE_TIME);
   keypad.setHoldTime(KEYPAD_HOLD_TIME);

--- a/config_buttons_example.h
+++ b/config_buttons_example.h
@@ -19,6 +19,13 @@
 // increase if you find the encoder buttons bounce (activate twice) or you get speed changes when you press the encoder button
 // #define ROTARY_ENCODER_DEBOUNCE_TIME 200
 
+//Internal GPIO pullups required if the hardware build utilises a bare EC11 rotary encoder in place of a
+//KY040 encoder module. (The encoder module has physical pullups fitted)
+//true = bare EC11 used for hardware build WITHOUT any physical pullups, GPIO pullups will ne enabled in main
+//false = KY040 module used in hardware build OR bare EC11 used but with physical pullup resistors (default false)
+
+#define EC11_PULLUPS_REQUIRED         false
+
 // ********************************************************************************************
 
 // define what each button will do as direct press (not in a menu)   * and # cannot be remapped

--- a/static.h
+++ b/static.h
@@ -1,5 +1,5 @@
 const String appName = "WiTcontroller";
-const String appVersion = "     Version 1.51";
+const String appVersion = "     Version 1.53";
 
 #ifndef DEVICE_NAME
    #define DEVICE_NAME "WiTcontroller"
@@ -541,6 +541,14 @@ const char ssidPasswordBlankChar = 164;
 
 #ifndef SEARCH_ROSTER_ON_ENTRY_OF_DCC_ADDRESS
   #define SEARCH_ROSTER_ON_ENTRY_OF_DCC_ADDRESS false
+#endif
+
+// *******************************************************************************************************************
+// if bare EC11 rotary encoder is used rather than KY040 then ESP32 GPIO internal pullups must be enabled. Set default to be false
+// as the prototype build used KY040 encoder module that incorporates physical resistors
+
+#ifndef EC11_PULLUPS_REQUIRED
+  #define EC11_PULLUPS_REQUIRED false
 #endif
 
 // *******************************************************************************************************************


### PR DESCRIPTION
Add support for bare EC11 encoder hardware build.

Have added new 'define' relating to pullups required on GPIO connected to EC11. Modified static.h, config_buttons_example.h, WiTcontroller.ino and readme.md files.

Note that DIFF shows the static.h going from v1.51 to v1.53!      That's because I think I forgot to modify static.h from v1.51 to v1.52 in my last PR. Sorry about that. V1.53 is definitely the version for EC11 support and I have tested for EC11 and KY040 variant hardware.