### PR TITLE
add option to display loco name instead of dcc address

### DIFF
--- a/WiTcontroller.ino
+++ b/WiTcontroller.ino
@@ -2405,6 +2405,20 @@ String getDisplayLocoString(int multiThrottleIndex, int index) {
   char multiThrottleIndexChar = getMultiThrottleChar(multiThrottleIndex);
   String loco = wiThrottleProtocol.getLocomotiveAtPosition(multiThrottleIndexChar, index);
   String locoNumber = loco.substring(1);
+  
+  #ifdef DISPLAY_LOCO_NAME
+    int i = maxRoster;
+    while (i > 0) {
+      i--;
+      if (String(rosterAddress[i]) == locoNumber) {
+        if (rosterName[i] != "") {
+          locoNumber = rosterName[i] + "  ";
+        }
+        i = -1;
+      }
+    }
+  #endif
+  
   if (!wiThrottleProtocol.getLocomotiveAtPosition(multiThrottleIndexChar, 0).equals(loco)) { // not the lead loco
     Direction leadLocoDirection 
         = wiThrottleProtocol.getDirection(multiThrottleIndexChar, 

--- a/WiTcontroller.ino
+++ b/WiTcontroller.ino
@@ -2407,14 +2407,12 @@ String getDisplayLocoString(int multiThrottleIndex, int index) {
   String locoNumber = loco.substring(1);
   
   #ifdef DISPLAY_LOCO_NAME
-    int i = maxRoster;
-    while (i > 0) {
-      i--;
+    for (int i = 0; i < maxRoster; i++) {
       if (String(rosterAddress[i]) == locoNumber) {
         if (rosterName[i] != "") {
-          locoNumber = rosterName[i] + "  ";
+          locoNumber = rosterName[i];
         }
-        i = -1;
+        break;
       }
     }
   #endif
@@ -3131,6 +3129,7 @@ void writeOledSpeed() {
   String sLocos = "";
   String sSpeed = "";
   String sDirection = "";
+  String sSpaceBetweenLocos = " ";
 
   bool foundNextThrottle = false;
   String sNextThrottleNo = "";
@@ -3144,8 +3143,9 @@ void writeOledSpeed() {
     // oledText[0] = label_locos; oledText[2] = label_speed;
   
     for (int i=0; i < wiThrottleProtocol.getNumberOfLocomotives(currentThrottleIndexChar); i++) {
-      // sLocos = sLocos + " " + wiThrottleProtocol.getLocomotiveAtPosition(currentThrottleIndexChar, i);
-      sLocos = sLocos + " " + getDisplayLocoString(currentThrottleIndex, i);
+      // sLocos = sLocos + sSpaceBetweenLocos + wiThrottleProtocol.getLocomotiveAtPosition(currentThrottleIndexChar, i);
+      sLocos = sLocos + sSpaceBetweenLocos + getDisplayLocoString(currentThrottleIndex, i);
+      sSpaceBetweenLocos = CONSIST_SPACE_BETWEEN_LOCOS;
     }
     // sSpeed = String(currentSpeed[currentThrottleIndex]);
     sSpeed = String(getDisplaySpeed(currentThrottleIndex));

--- a/config_buttons_example.h
+++ b/config_buttons_example.h
@@ -372,4 +372,7 @@
 // Display Loco name
 
 // Uncomment if you want to display the loco name instead of DCC address
-#define DISPLAY_LOCO_NAME
+// #define DISPLAY_LOCO_NAME
+
+// if you want to change the space between two loco names/ dcc addresses
+// #define CONSIST_SPACE_BETWEEN_LOCOS " "

--- a/config_buttons_example.h
+++ b/config_buttons_example.h
@@ -367,3 +367,9 @@
 // Enabling this option will automatically acquire the only roster entry after connection to the 
 // WiThrottle Server, but only if there is only one roster entry 
 // #define ACQUIRE_ROSTER_ENTRY_IF_ONLY_ONE true
+
+// *******************************************************************************************************************
+// Display Loco name
+
+// Uncomment if you want to display the loco name instead of DCC address
+#define DISPLAY_LOCO_NAME

--- a/static.h
+++ b/static.h
@@ -975,3 +975,10 @@ const char ssidPasswordBlankChar = 164;
 #ifndef ACQUIRE_ROSTER_ENTRY_IF_ONLY_ONE
    #define ACQUIRE_ROSTER_ENTRY_IF_ONLY_ONE false
 #endif
+
+// ***************************************************
+// other text
+
+#ifndef CONSIST_SPACE_BETWEEN_LOCOS
+   #define CONSIST_SPACE_BETWEEN_LOCOS " "
+#endif


### PR DESCRIPTION
Add a option to display loco name instead of the DCC address.
Maybe there is an more efficent way to get the loco name.